### PR TITLE
Add GitHub 3D contributions

### DIFF
--- a/.github/workflows/profile-3d.yml
+++ b/.github/workflows/profile-3d.yml
@@ -1,0 +1,28 @@
+name: Update 3D contribution graph
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Generate 3D contribution files
+        uses: yoshi389111/github-profile-3d-contrib@v1
+        with:
+          user_name: sminerport
+          output_dir: profile-3d-contrib
+          token: ${{ secrets.PAT_3D }}
+      - name: Commit files
+        run: |
+          git config user.name 'github-actions'
+          git config user.email 'actions@github.com'
+          git add profile-3d-contrib
+          git commit -m 'chore: update 3d contributions' || echo 'No changes'
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_3D }}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@
   <img src="https://raw.githubusercontent.com/sminerport/snk/output/github-contribution-grid-snake-reverse.svg" alt="Snake Game" />
 </p>
 
+<!-- 3D Contribution Graph -->
+<p align="center">
+  <img src="./profile-3d-contrib/profile-night-rainbow.svg" alt="3D GitHub Contribution Graph"/>
+</p>
+
 
 # 📜 Latest Blog Posts
 


### PR DESCRIPTION
## Summary
- show a 3D contributions SVG in the README
- add `profile-3d-contrib` folder to hold generated SVGs
- automate creation of the 3D graph in `profile-3d.yml`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683c8e81bc34832bb7ba5a44f3882e96