### PR TITLE
Fix 3D contribution workflow

### DIFF
--- a/.github/workflows/profile-3d.yml
+++ b/.github/workflows/profile-3d.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Generate 3D contribution files
-        uses: yoshi389111/github-profile-3d-contrib@v1
+        uses: yoshi389111/github-profile-3d-contrib@v2
         with:
           user_name: sminerport
           output_dir: profile-3d-contrib


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to use `@v2` of the 3D contribution graph action

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683c92588cbc832ba7ba20c1a7babbd6