### PR TITLE
Fix 3d workflow action version

### DIFF
--- a/.github/workflows/profile-3d.yml
+++ b/.github/workflows/profile-3d.yml
@@ -3,6 +3,11 @@ name: Update 3D contribution graph
 on:
   schedule:
     - cron: '0 0 * * *'
+  push:
+    branches:
+      - main
+      - dev
+      - prod
   workflow_dispatch:
 
 jobs:
@@ -12,7 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Generate 3D contribution files
-        uses: yoshi389111/github-profile-3d-contrib@v2
+        uses: yoshi389111/github-profile-3d-contrib@latest
         with:
           user_name: sminerport
           output_dir: profile-3d-contrib


### PR DESCRIPTION
## Summary
- run the 3D contribution workflow on pushes to `main`, `dev`, and `prod`
- use the `latest` version of `github-profile-3d-contrib`

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683c93f3eb34832bb7a0c051e170f01f